### PR TITLE
Fix i3 config line

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ opacity-rule = [
 Notice the focused then unfocused lines and the tabs before the lines.
 
 If you wish to bind this to a key in i3 use this format in i3's config file:
+```
 bindsym --release $mod+t exec --no-startup-id notify-send "$(bash ~/.config/picom-tool.sh)"
+```
 
 If your picom.conf file is not located in ~/.config/ you will have to edit the bash script variable mydir. Transfoc and transunfoc variables are the values for the transparency for focused and not focused windows and can be changed. 
 


### PR DESCRIPTION
`bindsym` line is interpreted as regular text which leads to wrong formatting due to special characters like `$`. This makes it hard to copy the line.

This commit formats line as codeblock